### PR TITLE
Fix commentable rolw validation

### DIFF
--- a/lib/parole/comment.rb
+++ b/lib/parole/comment.rb
@@ -45,6 +45,8 @@ module Parole
     # If the commentable doesn't have any comment roles, we make sure
     # that the value is blank.
     def ensure_valid_role_for_commentable
+      return false unless commentable.present?
+      
       allowed_roles = commentable.class.commentable_options[:roles]
 
       if allowed_roles.any?


### PR DESCRIPTION
When commentable is nil, calling commentable.class will succeed but calling commentable_options on NilClass will raise a NoMethodError
