### PR TITLE
Fix Comment validation when commentable association is not set

### DIFF
--- a/lib/parole/comment.rb
+++ b/lib/parole/comment.rb
@@ -45,6 +45,7 @@ module Parole
     # If the commentable doesn't have any comment roles, we make sure
     # that the value is blank.
     def ensure_valid_role_for_commentable
+      return unless commentable
       allowed_roles = commentable.class.commentable_options[:roles]
 
       if allowed_roles.any?

--- a/spec/parole/comment_spec.rb
+++ b/spec/parole/comment_spec.rb
@@ -110,4 +110,23 @@ describe Parole::Comment do
       it { expect { create_comment! }.to change { commentable.reload.comments_count }.from(0).to(1) }
     end
   end
+
+  describe :ensure_valid_role_for_commentable do
+    before do
+      spawn_comment_model
+      spawn_commenter_model 'User'
+
+      run_migration do
+        create_table(:users, force: true)
+      end
+    end
+
+    let(:commenter) { User.create }
+
+    context 'without associated commentable' do
+      let(:comment) { Comment.new(commenter: commenter, comment: 'Booya') }
+
+      it { expect { comment.valid? }.to_not raise_error }
+    end
+  end
 end


### PR DESCRIPTION
Instantiating a bare `Comment` should not raise. Might want to implement the fix by doing `validate :ensure_valid_role_for_commentable, if: -> { commentable.present? }` but I have a strong preference for this PR's implementation.
