### PR TITLE
Add cache counter for commenter model

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,22 @@ article.comments.count # => 1
 
 ### Cache counters
 
-Whenever a comment is created or destroyed, Parole looks into the commentable record and check
-if there’s a `<role>_comments_count` column and/or a `comments_count` column. If so, it updates
-them so they reflect the total number of comments and the number of comments of this role for
-the record.
+Whenever a comment is created or destroyed, Parole looks into the commentable record and the commenter
+record and check if there’s a `<role>_comments_count` column and/or a `comments_count` column.
+If so, it updates them so they reflect the total number of comments and the number of comments
+of this role for the record.
 
-So let’s say the `Article` model has the following columns: `photos_comments_count`, `videos_comments_count` and `comments_count`.
+_Note:_ The commenter model must implements a `has_many` relationship that fetch its comments.
+
+So let’s say the `Article` model has the following columns: `photos_comments_count`, `videos_comments_count` and `comments_count`,
+and the `User` model has the following column: `comments_count`.
 
 ```ruby
 class Article < ActiveRecord::Base
   acts_as_commentable roles: [:photos, :videos]
+end
+class User < ActiveRecord::Base
+  has_many :comments, -> { where(commenter_type: 'User') }, foreign_key: :commenter_id
 end
 
 user = User.find(1)
@@ -83,11 +89,13 @@ article.photos_comments.create(commenter: user, comment: 'Hello world!')
 article.photos_comments_count # => 1
 article.videos_comments_count # => 0
 article.comments_count # => 1
+user.comments_count # => 1
 
 article.videos_comments.create(commenter: user, comment: 'Hello world again!')
 article.photos_comments_count # => 1
 article.videos_comments_count # => 1
 article.comments_count # => 2
+user.comments_count # => 2
 ```
 
 ## License

--- a/lib/parole/comment.rb
+++ b/lib/parole/comment.rb
@@ -24,19 +24,28 @@ module Parole
     # Update the commentable cache counter columns
     #
     # Look for a `<role>_comments_count` and a `comments_count` column
-    # in the commentable model and update their value with the count.
+    # in the commentable model and the commenter model and update their value with the count.
     def update_cache_counters
+      commenter_has_comments = commenter.respond_to?(:comments)
+
       role_method = :"#{self.role}_comments_count="
       if commentable.respond_to?(role_method)
         commentable.send role_method, commentable.comments.where(role: self.role).count
+      end
+      if commenter_has_comments && commenter.respond_to?(role_method)
+        commenter.send role_method, commenter.comments.where(role: self.role).count
       end
 
       total_method = :comments_count=
       if commentable.respond_to?(total_method)
         commentable.send total_method, commentable.comments.count
       end
+      if commenter_has_comments && commenter.respond_to?(total_method)
+        commenter.send total_method, commenter.comments.count
+      end
 
       commentable.save(validate: false)
+      commenter.save(validate: false)
     end
 
     # Make sure that the value of the `role` attribute is a valid role


### PR DESCRIPTION
Pretty simple: implements the same cache counter assignments for the commenter model as in the commentable model. The only difference is that the commenter model must implements a `comments` method that fetches its comments (as pointed in the updated README.md section).