### PR TITLE
Add “acts_as_commenter”

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: ruby
 
 rvm:
-  - 2.0.0
-  - 1.9.3
+  - 2.2.0
+
+sudo: false
 
 gemfile:
   - gemfiles/Gemfile.activerecord-4.0
+  - gemfiles/Gemfile.activerecord-4.1
+  - gemfiles/Gemfile.activerecord-4.2
 
 script: "echo 'DO IT' && bundle exec rake spec"
 

--- a/gemfiles/Gemfile.activerecord-4.1
+++ b/gemfiles/Gemfile.activerecord-4.1
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 4.1.0'

--- a/gemfiles/Gemfile.activerecord-4.2
+++ b/gemfiles/Gemfile.activerecord-4.2
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 4.2.0'

--- a/lib/generators/parole/templates/migration.rb
+++ b/lib/generators/parole/templates/migration.rb
@@ -6,7 +6,7 @@ class AddParole < ActiveRecord::Migration
       t.string :role
       t.text :comment
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_index :comments, [:commentable_type, :commentable_id, :role]

--- a/lib/parole.rb
+++ b/lib/parole.rb
@@ -4,22 +4,33 @@ require 'active_record'
 require 'active_support'
 
 require 'parole/commentable'
+require 'parole/commenter'
 require 'parole/comment'
 
 class ActiveRecord::Base
   def self.acts_as_commentable(options = {})
-    Parole.commentable_classes << self
-
     class_attribute :commentable_options, :actually_acts_as_commentable
     self.actually_acts_as_commentable = true
+
     self.commentable_options = options.reverse_merge(roles: [])
     self.commentable_options[:roles] = commentable_options[:roles].map(&:to_s)
 
     include Parole::Commentable
   end
 
+  def self.acts_as_commenter(options = {})
+    class_attribute :actually_acts_as_commenter
+    self.actually_acts_as_commenter = true
+
+    include Parole::Commenter
+  end
+
   def self.acts_as_commentable?
     self.respond_to?(:actually_acts_as_commentable) && self.actually_acts_as_commentable
+  end
+
+  def self.acts_as_commenter?
+    self.respond_to?(:actually_acts_as_commenter) && self.actually_acts_as_commenter
   end
 
   def self.acts_as_comment(*args)
@@ -29,10 +40,8 @@ class ActiveRecord::Base
   def commentable?
     self.class.acts_as_commentable?
   end
-end
 
-module Parole
-  def self.commentable_classes
-    @commentable_classes ||= []
+  def commenter?
+    self.class.acts_as_commenter?
   end
 end

--- a/lib/parole/commenter.rb
+++ b/lib/parole/commenter.rb
@@ -1,0 +1,17 @@
+module Parole
+  module Commenter
+    extend ActiveSupport::Concern
+
+    included do
+      # Default options for all comments associations
+      association_options = { class_name: 'Comment', as: :commenter, dependent: :destroy }
+
+      # All comments for the record
+      has_many :comments, association_options
+
+      # Role-specific comments for the record
+      # TODO: We need to find a way to register global roles, because roles
+      # are currently bound to commentable models
+    end
+  end
+end

--- a/parole.gemspec
+++ b/parole.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'sqlite3'
-  spec.add_development_dependency 'rspec', '~> 2.14'
+  spec.add_development_dependency 'rspec', '~> 3.2'
 
   spec.add_dependency 'activerecord', '>= 4.0.0'
   spec.add_dependency 'activesupport', '>= 4.0.0'

--- a/spec/parole/comment_spec.rb
+++ b/spec/parole/comment_spec.rb
@@ -124,9 +124,7 @@ describe Parole::Comment do
     describe :update_cache_counters do
       before do
         spawn_comment_model
-        spawn_commenter_model 'User' do
-          has_many :comments, -> { where(commenter_type: 'User') }, foreign_key: :commenter_id
-        end
+        spawn_commenter_model 'User'
         spawn_commentable_model 'Article' do
           acts_as_commentable roles: [:photos, :videos]
         end
@@ -147,7 +145,7 @@ describe Parole::Comment do
 
       let(:commenter) { User.create }
       let(:commentable) { Article.create }
-      let(:create_comment!) { commentable.photos_comments.create(commenter: commenter, comment: 'Booya') }
+      let(:create_comment!) { commentable.photos_comments.create!(commenter: commenter, comment: 'Booya') }
 
       # Commentable cache counter
       it { expect { create_comment! }.to change { commentable.reload.photos_comments_count }.from(0).to(1) }

--- a/spec/parole/commentable_spec.rb
+++ b/spec/parole/commentable_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 
 describe Parole::Commentable do
   describe 'general `comments` relation' do
-    let(:relation_class) { ActiveRecord::Associations::CollectionProxy::ActiveRecord_Associations_CollectionProxy_Comment }
-
     context 'without defined roles' do
       before do
         spawn_comment_model
@@ -14,7 +12,7 @@ describe Parole::Commentable do
         end
       end
 
-      it { expect(Article.create.comments).to be_instance_of(ActiveRecord::Associations::CollectionProxy::ActiveRecord_Associations_CollectionProxy_Comment) }
+      it { expect(Article.create.comments).not_to be_loaded }
       it { expect(Article.create.comments.new.role).to be_blank }
     end
 
@@ -30,9 +28,10 @@ describe Parole::Commentable do
         end
       end
 
-      it { expect(Article.create.comments).to be_instance_of(relation_class) }
-      it { expect(Article.create.photos_comments).to be_instance_of(relation_class) }
-      it { expect(Article.create.videos_comments).to be_instance_of(relation_class) }
+      it { expect(Article.create.comments).not_to be_loaded }
+      it { expect(Article.create.photos_comments).not_to be_loaded }
+      it { expect(Article.create.videos_comments).not_to be_loaded }
+
       it { expect(Article.create.comments.new.role).to be_blank }
       it { expect(Article.create.photos_comments.new.role).to eql 'photos' }
       it { expect(Article.create.videos_comments.new.role).to eql 'videos' }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,9 +14,6 @@ RSpec.configure do |config|
   config.include ModelMacros
 
   config.before(:each) do
-    # Reset our commentable classes
-    Parole.instance_variable_set(:@commentable_classes, nil)
-
     # Create the SQLite database
     setup_database
 

--- a/spec/support/macros/model_macros.rb
+++ b/spec/support/macros/model_macros.rb
@@ -18,7 +18,7 @@ module ModelMacros
   # Create a new commenter model
   def spawn_commenter_model(klass_name = 'User', &block)
     spawn_model klass_name, ActiveRecord::Base do
-      has_many :comments unless block
+      acts_as_commenter unless block
       instance_exec(&block) if block
     end
   end


### PR DESCRIPTION
We now have an `acts_as_commenter` method to make sure that the `Comment@commenter` association works only with records that actually belong to a _commenter_ model.

I also tidied up the `.travis.yml` configuration file!
